### PR TITLE
expat/expat: Update to R_2_5_0

### DIFF
--- a/expat/idf_component.yml
+++ b/expat/idf_component.yml
@@ -1,4 +1,4 @@
-version: "2.4.8"
+version: "2.5.0"
 description: "Expat - XML Parsing C Library"
 url: https://github.com/espressif/idf-extra-components/tree/master/expat
 dependencies:


### PR DESCRIPTION

Changes between 3bab6c09bbe8bf42d84b81563ddbcf4cca4be838 and 654d2de0da85662fcc7644a7acd7c2dd2cfb21f0:

- https://github.com/libexpat/libexpat/commit/654d2de0: Merge pull request #668 from libexpat/issue-667-prepare-release
- https://github.com/libexpat/libexpat/commit/fe8ff034: Changes: Add note on impact of CVE-2022-43680
- https://github.com/libexpat/libexpat/commit/18439d4f: Merge pull request #666 from libexpat/improve-examples
- https://github.com/libexpat/libexpat/commit/acbbef94: Set release date for version 2.5.0
- https://github.com/libexpat/libexpat/commit/82a9c09f: Changes: Document #656 #658
- https://github.com/libexpat/libexpat/commit/454c6105: Bump version to 2.5.0
- https://github.com/libexpat/libexpat/commit/db20f724: Bump version info from 9:9:8 to 9:10:8
- https://github.com/libexpat/libexpat/commit/7e27f561: Sync file headers
- https://github.com/libexpat/libexpat/commit/56967f83: Merge pull request #650 from libexpat/issue-649-fix-overeager-dtd-destruction
- https://github.com/libexpat/libexpat/commit/55ca0011: Changes: Document #666
- https://github.com/libexpat/libexpat/commit/a608db28: cmake: Resolve duplication related to building examples
- https://github.com/libexpat/libexpat/commit/9294082e: examples: Add some whitespace for readability
- https://github.com/libexpat/libexpat/commit/dbf12025: examples: Make use of XML_GetBuffer
- https://github.com/libexpat/libexpat/commit/2f380317: examples/elements.c: Resolve unused include of <wchar.h>
- https://github.com/libexpat/libexpat/commit/77409cde: examples/elements.c: Be consistent across examples regarding OOM detection
- https://github.com/libexpat/libexpat/commit/894b98d9: examples: Be consistent across examples regarding read looping and main exit
- https://github.com/libexpat/libexpat/commit/37386fd2: examples/elements.c: Be consistent in parse error reporting format across examples
- https://github.com/libexpat/libexpat/commit/2b3b95c6: examples/outline.c: Be consistent in main loop exit across examples
- https://github.com/libexpat/libexpat/commit/023b95db: examples/outline.c: Make element handler signatures consistent across examples
- https://github.com/libexpat/libexpat/commit/93a757ab: examples/outline.c: Make use of BUFSIZ from stdio.h consistent across examples
- https://github.com/libexpat/libexpat/commit/fcb91e43: examples: Make passing of depth pointer consistent across examples
- https://github.com/libexpat/libexpat/commit/9c7bd378: examples: Resolve use of unused variables argc and argv
- https://github.com/libexpat/libexpat/commit/5ac71407: Merge pull request #665 from libexpat/dependabot/github_actions/actions/upload-artifact-3.1.1
- https://github.com/libexpat/libexpat/commit/eedc5f6d: Changes: Document #649
- https://github.com/libexpat/libexpat/commit/43992e4a: tests: Cover overeager DTD destruction in XML_ExternalEntityParserCreate
- https://github.com/libexpat/libexpat/commit/5290462a: lib: Fix overeager DTD destruction in XML_ExternalEntityParserCreate
- https://github.com/libexpat/libexpat/commit/66dc6066: Actions(deps): Bump actions/upload-artifact from 3.1.0 to 3.1.1
- https://github.com/libexpat/libexpat/commit/56d85659: examples/outline.c: Rename "Buff" to "buf" for consistency across examples
- https://github.com/libexpat/libexpat/commit/bd351fad: examples/outline.c: Make "Buff" a local variable
- https://github.com/libexpat/libexpat/commit/7eaccc03: examples/outline.c: Rename variable "p" to "parser"
- https://github.com/libexpat/libexpat/commit/39155162: Merge pull request #663 from libexpat/expat-config-h-multiple-inclusion-guard
- https://github.com/libexpat/libexpat/commit/6393f2d3: Protect expat_config.h against multiple inclusion
- https://github.com/libexpat/libexpat/commit/91920104: Merge pull request #654 from libexpat/issue-613-fix-processing-of-nested-entities
- https://github.com/libexpat/libexpat/commit/6acab0a2: Changes: Document #613
- https://github.com/libexpat/libexpat/commit/fc95d53e: tests: Cover suspend with inside nested entites in internalEntityProcessor
- https://github.com/libexpat/libexpat/commit/6fa8957d: lib: Fix suspend with inside nested entites in internalEntityProcessor
- https://github.com/libexpat/libexpat/commit/9d26eda6: lib: Simplify control flow in internalEntityProcessor
- https://github.com/libexpat/libexpat/commit/15026eb8: Merge pull request #653 from libexpat/issue-652-stop-leaking-tag-bindings
- https://github.com/libexpat/libexpat/commit/46810602: Merge pull request #659 from libexpat/dependabot/github_actions/actions/checkout-3.1.0
- https://github.com/libexpat/libexpat/commit/cfa1c20b: Actions(deps): Bump actions/checkout from 3.0.2 to 3.1.0
- https://github.com/libexpat/libexpat/commit/ea4a24d7: Merge pull request #658 from Osyotr/patch-1
- https://github.com/libexpat/libexpat/commit/90bc7cf0: Fix static library name when building with mingw
- https://github.com/libexpat/libexpat/commit/8510b2c5: Changes: Document #652
- https://github.com/libexpat/libexpat/commit/16a4db92: lib: Stop leaking opening tag bindings after closing tag mismatch error
- https://github.com/libexpat/libexpat/commit/d7ea13f5: tests: Cover leak of opening tag bindings after closing tag mismatch error
- https://github.com/libexpat/libexpat/commit/eb976a36: Merge pull request #645 from libexpat/issue-612-fix-corruption-from-undefined-entities
- https://github.com/libexpat/libexpat/commit/7185eee9: [2.4.9] CMake: Fix generation of pkgconfig file (#656)
- https://github.com/libexpat/libexpat/commit/c7b54659: fix typos (#655)
- https://github.com/libexpat/libexpat/commit/fa1efbac: Changes: Document #612 #645
- https://github.com/libexpat/libexpat/commit/1bdbde26: Fix curruption from undefined entities (fixes #612)
- https://github.com/libexpat/libexpat/commit/c697c3ed: Regression test for #612: tempPool corrupt from attribute types.
- https://github.com/libexpat/libexpat/commit/b4eecc13: Merge pull request #648 from libexpat/issue-648-tests-fix-warning-missing-prototypes
- https://github.com/libexpat/libexpat/commit/9f13b5b5: tests: Address GCC warning -Wmissing-prototypes
- https://github.com/libexpat/libexpat/commit/d77291a4: Merge pull request #644 from libexpat/issue-642-release-2-4-9
- https://github.com/libexpat/libexpat/commit/869b3dea: Set release date for version 2.4.9
- https://github.com/libexpat/libexpat/commit/a7103d40: Bump version to 2.4.9
- https://github.com/libexpat/libexpat/commit/88462ba0: Bump version info from 9:8:8 to 9:9:8
- https://github.com/libexpat/libexpat/commit/f70d53f2: Changes: Document #592 #593 #594 #614 #619 #627 #633 #635 #636 #637
- https://github.com/libexpat/libexpat/commit/55b79f4d: Sync file headers
- https://github.com/libexpat/libexpat/commit/86a4093a: Resolve use of deprecated "fgrep" by "grep -F"
- https://github.com/libexpat/libexpat/commit/7430d287: win32/build_expat_iss.bat: Add -DEXPAT_WARNINGS_AS_ERRORS=ON
- https://github.com/libexpat/libexpat/commit/be320251: Merge pull request #643 from libexpat/clang-15
- https://github.com/libexpat/libexpat/commit/d139637b: Actions: Upgrade Clang from 14 to 15
- https://github.com/libexpat/libexpat/commit/d88c9510: tests: Address Clang 15 warning -Wstrict-prototypes
- https://github.com/libexpat/libexpat/commit/a976e32a: Merge pull request #640 from libexpat/issue-629-heap-use-after-free
- https://github.com/libexpat/libexpat/commit/721169ee: Changes: Document heap use-after-free CVE-2022-40674
- https://github.com/libexpat/libexpat/commit/a7ce80a0: tests: Cover heap use-after-free issue in doContent
- https://github.com/libexpat/libexpat/commit/a48c4070: Merge pull request #641 from libexpat/issue-626-static-library-symbol-visibility
- https://github.com/libexpat/libexpat/commit/107437ad: Stop exporting API symbols when building a static library
- https://github.com/libexpat/libexpat/commit/dde178b9: Merge pull request #629 from RMJ10/missing-store-raw
- https://github.com/libexpat/libexpat/commit/528dbea4: Merge pull request #627 from libexpat/issue-597-cmake-migrate-set-cache-to-option
- https://github.com/libexpat/libexpat/commit/67db2adb: cmake: Mark _EXPAT_M32 and EXPAT_*_POSTFIX as advanced
- https://github.com/libexpat/libexpat/commit/cb10e651: cmake: Unify set(var default CACHE type desc) and option(var desc default)
- https://github.com/libexpat/libexpat/commit/1cc2b29c: Merge pull request #632 from libexpat/github-actions-off-deprecated-ubuntu-18-04
- https://github.com/libexpat/libexpat/commit/0d2def4c: Changes: Briefly document infra work
- https://github.com/libexpat/libexpat/commit/84bec8c7: GitHub Actions: Pin remaining unpinned ubuntu-latest
- https://github.com/libexpat/libexpat/commit/55ebc6d0: GitHub Actions: Stop installing Clang when not used
- https://github.com/libexpat/libexpat/commit/1156ae7d: GitHub Actions: Avoid Ubuntu 20.04 for coverage collection
- https://github.com/libexpat/libexpat/commit/003ac740: coverage.sh|qa.sh: Fix copying of DLLs for Wine/MinGW for Ubuntu 22.04
- https://github.com/libexpat/libexpat/commit/6311d585: GitHub Actions: Fix installation of 32bit Wine on Ubuntu 20.04
- https://github.com/libexpat/libexpat/commit/666a749f: GitHub Actions: Get off deprecated Ubuntu 18.04
- https://github.com/libexpat/libexpat/commit/80e6c691: cmake: Avoid error "windres: Command not found" with MinGW on Ubuntu 20.04
- https://github.com/libexpat/libexpat/commit/9d246a72: Merge pull request #636 from neheb/patch-1
- https://github.com/libexpat/libexpat/commit/fa9f063f: Merge pull request #637 from neheb/cl
- https://github.com/libexpat/libexpat/commit/acf35f3f: Merge pull request #638 from libexpat/fix-xmltest-log-sh-drop-more-wine-bug-output
- https://github.com/libexpat/libexpat/commit/05e90411: fix-xmltest-log.sh: Drop more Wine bug output
- https://github.com/libexpat/libexpat/commit/0b826ea2: Merge pull request #635 from libexpat/coverage-sh-fix-name-collision
- https://github.com/libexpat/libexpat/commit/2e4ff883: remove leading whitespace from config file
- https://github.com/libexpat/libexpat/commit/cf0072d2: apply-clang-format: add support for BSD find
- https://github.com/libexpat/libexpat/commit/fff6ef4c: Merge pull request #634 from libexpat/fix-mingw-compilation
- https://github.com/libexpat/libexpat/commit/62259703: coverage.sh: Fix name collision for -funsigned-char
- https://github.com/libexpat/libexpat/commit/446688c6: lib: Fix compilation for -D__USE_MINGW_ANSI_STDIO=0
- https://github.com/libexpat/libexpat/commit/cc3ddda5: Merge pull request #633 from libexpat/coverage-sh-exclude-mingw-headers
- https://github.com/libexpat/libexpat/commit/9188cba7: coverage.sh: Exclude MinGW headers (stdio.h and stdlib.h)
- https://github.com/libexpat/libexpat/commit/230b490c: coverage.sh: Inline exclusion patterns (for upcoming change)
- https://github.com/libexpat/libexpat/commit/0a0418fa: File expat/fuzz/.gitignore changed to not ignore already-committed source files (fixes #630) (#631)
- https://github.com/libexpat/libexpat/commit/4a32da87: Ensure raw tagnames are safe exiting internalEntityParser
- https://github.com/libexpat/libexpat/commit/11598f34: Merge pull request #625 from libexpat/autotools-sync-cmake-files
- https://github.com/libexpat/libexpat/commit/2d310432: Changes: Document past Autotools Cmake template adjustments in more detail
- https://github.com/libexpat/libexpat/commit/c09cb677: autotools: Sync CMake templates with CMake 3.22
- https://github.com/libexpat/libexpat/commit/f97479d7: Merge pull request #624 from libexpat/issue-622-mingw-cmake-dll-filename
- https://github.com/libexpat/libexpat/commit/7731dd5b: cmake: Produce libexpat-1.dll with MinGW in line with GNU Autotools
- https://github.com/libexpat/libexpat/commit/e12e9ffb: Merge pull request #621 from libexpat/issue-512-windows-render-def-files-from-template
- https://github.com/libexpat/libexpat/commit/0fb9a620: cmake: Apply .def file when linking with MinGW
- https://github.com/libexpat/libexpat/commit/bc2d690a: cmake|windows: Render .def file from a template to fix linking
- https://github.com/libexpat/libexpat/commit/9c66cb37: Merge pull request #620 from libexpat/cmake-improve-documentation-on-variables
- https://github.com/libexpat/libexpat/commit/89dc0f26: Merge pull request #611 from neheb/def
- https://github.com/libexpat/libexpat/commit/ca2cc7ea: Merge pull request #614 from Tieske/minor
- https://github.com/libexpat/libexpat/commit/260c5190: Changes: Document #608 and #620
- https://github.com/libexpat/libexpat/commit/d4ecd87e: readme: Get CMake variables documentation back in sync
- https://github.com/libexpat/libexpat/commit/aa65f8ca: cmake: Make all variable documentation start with a capital letter
- https://github.com/libexpat/libexpat/commit/ac6e1d0b: cmake: Improve documentation of variables EXPAT_*_POSTFIX
- https://github.com/libexpat/libexpat/commit/0e9bd32b: cmake: Fix a CMAKE_*_POSTFIX leftover from pull request #608
- https://github.com/libexpat/libexpat/commit/2ba1ae67: Merge pull request #619 from libexpat/actions-get-off-deprecated-macos-10-15
- https://github.com/libexpat/libexpat/commit/6f746094: Merge pull request #608 from dfaure-kdab/master
- https://github.com/libexpat/libexpat/commit/7d6c0d8f: actions: Be explicit about macos-11
- https://github.com/libexpat/libexpat/commit/91432ad6: actions: Migrate from deprecated macos-10.15 to macos-11
- https://github.com/libexpat/libexpat/commit/5a263e75: Set target properties *_POSTFIX instead of global vars CMAKE_*_POSTFIX
- https://github.com/libexpat/libexpat/commit/f1a5b316: fix(docs) update XML_DTD symbol visibility
- https://github.com/libexpat/libexpat/commit/e36bcc2c: expat: fix def files for MinGW
- https://github.com/libexpat/libexpat/commit/68e60b56: Merge pull request #610 from libexpat/address-cppcheck-2-8-1-warning
- https://github.com/libexpat/libexpat/commit/6101fbc1: lib: Address Cppcheck 2.8.1 warning
- https://github.com/libexpat/libexpat/commit/4e91da28: Merge pull request #609 from libexpat/issue-585-license-file
- https://github.com/libexpat/libexpat/commit/34f57a0b: COPYING: cp expat/COPYING ./
- https://github.com/libexpat/libexpat/commit/39b2e993: Sync file headers
- https://github.com/libexpat/libexpat/commit/24fa196a: .mailmap: Add Martin Ettl
- https://github.com/libexpat/libexpat/commit/f4501351: Merge pull request #603 from libexpat/dependabot/github_actions/actions/upload-artifact-3.1.0
- https://github.com/libexpat/libexpat/commit/3c6aaff6: Actions(deps): Bump actions/upload-artifact from 3.0.0 to 3.1.0
- https://github.com/libexpat/libexpat/commit/d444af3b: Merge pull request #602 from libexpat/dependabot/github_actions/actions/checkout-3.0.2
- https://github.com/libexpat/libexpat/commit/1e1bceb3: Actions(deps): Bump actions/checkout from 3.0.1 to 3.0.2
- https://github.com/libexpat/libexpat/commit/dc156ea1: [style] Added parentheses around macro arguments (#601)
- https://github.com/libexpat/libexpat/commit/38b14bb2: Merge pull request #595 from orbitcowboy/master
- https://github.com/libexpat/libexpat/commit/d010395c: Merge pull request #599 from libexpat/issue-597-windows-tests-xml-static
- https://github.com/libexpat/libexpat/commit/967fb8bb: Merge pull request #600 from libexpat/dependabot/github_actions/actions/checkout-3.0.1
- https://github.com/libexpat/libexpat/commit/00036b3e: Actions(deps): Bump actions/checkout from 3.0.0 to 3.0.1
- https://github.com/libexpat/libexpat/commit/4b92533b: CMake: Add missing XML_STATIC to test runners and fuzzers on Windows
- https://github.com/libexpat/libexpat/commit/6c7c40a6: CMake: Add missing section comment for fuzzers
- https://github.com/libexpat/libexpat/commit/aaf785b8: CMake: Extract loop to resolve runtests/runtestspp duplication
- https://github.com/libexpat/libexpat/commit/dd969fc5: Merge pull request #598 from libexpat/appveyor-msvc2022
- https://github.com/libexpat/libexpat/commit/53ff63e1: appveyor.yml: Add MSVC 2022
- https://github.com/libexpat/libexpat/commit/88faa785: Merge pull request #596 from libexpat/sync-autotools-cmake-templates
- https://github.com/libexpat/libexpat/commit/1ba57f78: autotools: Sync expat.cmake to agree with CI
- https://github.com/libexpat/libexpat/commit/a100d013: [STYLE] Added parentheses around macro argument
- https://github.com/libexpat/libexpat/commit/e55290c7: Merge pull request #594 from orbitcowboy/master
- https://github.com/libexpat/libexpat/commit/4ead0836: Fixed typo in nsattcmp attribute handling
- https://github.com/libexpat/libexpat/commit/f1b05559: Merge pull request #593 from orbitcowboy/master
- https://github.com/libexpat/libexpat/commit/399a65e6: Assign LPVOID pointer with NULL before it's being used